### PR TITLE
Fix zookeeper annotations

### DIFF
--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -46,7 +46,9 @@ spec:
         {{- if .Values.zookeeper.restartPodsOnConfigMapChange }}
         checksum/config: {{ include (print $.Template.BasePath "/zookeeper-configmap.yaml") . | sha256sum }}
         {{- end }}
-{{ toYaml .Values.zookeeper.annotations | indent 8 }}
+{{- with .Values.zookeeper.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
     {{- if .Values.zookeeper.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Fixed the case when no ZK annotations are set and `zookeeper.restartPodsOnConfigMapChange: true` helm can not render template


### Motivation
When you don't set any annotations to Zookeeper (they are empty by default) AND if you set
```yaml
zookeeper.restartPodsOnConfigMapChange: true
```
in your values.yaml file, the manifest can not be rendered. This commit fixes this condition and also unifies the
way how the custom annotations are added, with bookkeeper statefulset template.

```
helm template pulsar apache/pulsar --version 3.0.0 --set zookeeper.restartPodsOnConfigMapChange=true  
Error: YAML parse error on pulsar/templates/zookeeper-statefulset.yaml: error converting YAML to JSON: yaml: line 52: did not find expected key

Use --debug flag to render out invalid YAML
```
### Modifications
wrapping `toYaml` filter (that can return empty object `{}`) into `with` context.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
